### PR TITLE
Add new parser for remove info after first colon.

### DIFF
--- a/cloudapp/src/app/models/call-number-parsers.ts
+++ b/cloudapp/src/app/models/call-number-parsers.ts
@@ -10,7 +10,7 @@ export const callNumberParsers: CallNumberParsers = {
   'remove_shelving_info': val => {
     if (Array.isArray(val)) val = val.join(' ');
     //const matches = val.match(/^[\w\s]*\/[\w\s]*\b/g);
-    const matches = val.match(/[0-9A-Za-z\s\/\.\:\(\)\#\+\-]+/g);
+    const matches = val.match(/[0-9A-Za-z\s\/\.\:\(\)\#\=\+\-]+/g);
     return ((matches && matches[0]) || val).split('/');
   }
 }

--- a/cloudapp/src/app/models/call-number-parsers.ts
+++ b/cloudapp/src/app/models/call-number-parsers.ts
@@ -11,5 +11,21 @@ export const callNumberParsers: CallNumberParsers = {
     if (Array.isArray(val)) val = val.join(' ');
     const matches = val.match(/[0-9A-Za-z\s\/\.\:\(\)\#\=\+\-]+/g);
     return ((matches && matches[0]) || val).split('/');
+  },
+  'remove_shelving_info_and_colon': val => {
+    if (Array.isArray(val)) val = val.join(' ');
+    const matches = val.match(/[0-9A-Za-z\s\/\.\:\(\)\#\=\+\-]+/g);
+    let strWithColon = (matches && matches[0]) || val;
+    if(strWithColon!= null && strWithColon.indexOf(":") != -1){
+      const matches_colon = strWithColon.match(/^.*\/.*:/);
+      let str = (matches_colon && matches_colon[0]) || strWithColon;
+      if(str != null && str.endsWith(":")){
+        str = str.substring(0,str.length-1);
+      }
+      return ((matches_colon && str) || strWithColon).split('/');
+    }else{
+      return ((matches && matches[0]) || val).split('/');
+    }
+    
   }
 }

--- a/cloudapp/src/app/models/call-number-parsers.ts
+++ b/cloudapp/src/app/models/call-number-parsers.ts
@@ -9,7 +9,8 @@ export const callNumberParsers: CallNumberParsers = {
   },
   'remove_shelving_info': val => {
     if (Array.isArray(val)) val = val.join(' ');
-    const matches = val.match(/^[\w\s]*\/[\w\s]*\b/g);
+    //const matches = val.match(/^[\w\s]*\/[\w\s]*\b/g);
+    const matches = val.match(/[0-9A-Za-z\s\/\.\:\(\)\#\+\-]+/g);
     return ((matches && matches[0]) || val).split('/');
   }
 }


### PR DESCRIPTION
The customer wants to print the part of call number before the first : character.
Adding a new parser (/^.*\/.*:/) called: remove_shelving_info_and_colon.